### PR TITLE
Skip images with 0 faces

### DIFF
--- a/morghulis/widerface/__init__.py
+++ b/morghulis/widerface/__init__.py
@@ -280,6 +280,10 @@ class Wider(BaseDataset):
                 log.debug(filename)
                 image = Image(os.path.join(images_dir, filename), filename)
                 face_num = int(f.readline().rstrip())
+
+                if face_num == 0:
+                    log.warning('No faces for {}. Ignoring next line {}'.format(image.filename, f.readline().rstrip()))
+
                 log.debug(face_num)
                 for _ in range(face_num):
                     anno = f.readline().rstrip().split()


### PR DESCRIPTION
Fix #16  

The images below in the widerface train dataset:

```
0--Parade/0_Parade_Parade_0_452.jpg
2_Demonstration_Political_Rally_2_444.jpg
39_Ice_Skating_iceskiing_39_380.jpg
46--Jockey/46_Jockey_Jockey_46_576.jpg
```

Have 0 faces and were confusing the parse logic.
